### PR TITLE
Update basemap to v1.1.0

### DIFF
--- a/doc/summary.md
+++ b/doc/summary.md
@@ -41,7 +41,7 @@
 - pyparsing==2.1.10
 - cycler==0.10.0
 - python_dateutil==2.6.0
-- _basemap==1.0.8_
+- _basemap==1.1.0
 - pyproj==1.9.5.1
 
 ## GMPE-SMTK ##
@@ -71,7 +71,7 @@ Xenial ships 1.8.9, but pyproj 1.8.9 sources disappeared from upstream. We use 1
 Xenial ships 1.8.7, but we'll use the latest release in 1.8 tree
 
 ### Basemap ###
-Basemap stable is 1.0.7 but it's incompatible with wheels; we are using 1.0.8 from github.
+Basemap stable is 1.0.7 but it's incompatible with wheels; we are using 1.1.0 from github.
 Currently it is not included in `oq-libs` because of its size. The plan is to move it
 in an 'extra' package.
 

--- a/doc/summary.md
+++ b/doc/summary.md
@@ -41,7 +41,7 @@
 - pyparsing==2.1.10
 - cycler==0.10.0
 - python_dateutil==2.6.0
-- _basemap==1.1.0
+- basemap==1.1.0
 - pyproj==1.9.5.1
 
 ## GMPE-SMTK ##

--- a/py27/requirements-bin.txt
+++ b/py27/requirements-bin.txt
@@ -1,6 +1,6 @@
 anyjson-0.3.3-cp27-none-any.whl
 # BASEMAP WILL BE PART OF AN EXTRA PACKAGE
-# basemap-1.0.8-cp27-cp27mu-manylinux1_x86_64.whl
+# basemap-1.1.0-cp27-cp27mu-manylinux1_x86_64.whl
 billiard-3.3.0.22-cp27-cp27mu-linux_x86_64.whl
 # CYTHON CURRENTLY NOT USED
 # Cython-0.23.4-cp27-cp27mu-manylinux1_x86_64.whl

--- a/py35/requirements-bin.txt
+++ b/py35/requirements-bin.txt
@@ -1,6 +1,6 @@
 anyjson-0.3.3-py3-none-any.whl
 # BASEMAP WILL BE PART OF AN EXTRA PACKAGE
-# basemap-1.0.8-cp35-cp35m-manylinux1_x86_64.whl
+# basemap-1.1.0-cp35-cp35m-manylinux1_x86_64.whl
 billiard-3.3.0.22-py3-none-any.whl
 # CYTHON CURRENTLY NOT USED
 # Cython-0.23.4-cp35-cp35m-manylinux1_x86_64.whl


### PR DESCRIPTION
Bump basemap version; our py35 wheel was broken too.

See also:

- https://github.com/gem/oq-containers/pull/12
- https://travis-ci.org/gem/oq-hazardlib/builds/211439632