### PR TITLE
Add support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,15 @@ dist: trusty
 language: python
 python:
     - 2.7
+    - 3.5
 
 install:
     # A newer virtualenv is required by whlsetup.sh to use the --no-download option
     - pip install -U virtualenv
-    - bash helpers/whldownload.sh -m http://cdn.ftp.openquake.org/wheelhouse/linux -w py -w py27 -w py27-extra
+    - bash helpers/whldownload.sh -m http://cdn.ftp.openquake.org/wheelhouse/linux -w py -w py${TRAVIS_PYTHON_VERSION//./} -w py${TRAVIS_PYTHON_VERSION//./}-extra
     - mkdir -p /tmp/opt/openquake
 
 
 script:
-    - bash helpers/whlsetup.sh -2 -s py -s py27 -s py27-extra -d /tmp/opt/openquake
-
+    - bash helpers/whlsetup.sh -${TRAVIS_PYTHON_VERSION:0:1}-s py -s py${TRAVIS_PYTHON_VERSION//./} -s py${TRAVIS_PYTHON_VERSION//./}-extra -d /tmp/opt/openquake
+    - python${TRAVIS_PYTHON_VERSION} -c 'from openquake.libs import __version__; print(__version__)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ install:
 
 
 script:
-    - bash helpers/whlsetup.sh -${TRAVIS_PYTHON_VERSION:0:1} -c -s py -s py${TRAVIS_PYTHON_VERSION//./} -s py${TRAVIS_PYTHON_VERSION//./}-extra -d /tmp/opt/openquake
+    - bash helpers/whlsetup.sh -${TRAVIS_PYTHON_VERSION%.*} -c -s py -s py${TRAVIS_PYTHON_VERSION//./} -s py${TRAVIS_PYTHON_VERSION//./}-extra -d /tmp/opt/openquake
     - python${TRAVIS_PYTHON_VERSION} -c 'from openquake.libs import __version__; print(__version__)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ install:
 
 
 script:
-    - bash helpers/whlsetup.sh -${TRAVIS_PYTHON_VERSION:0:1}-s py -s py${TRAVIS_PYTHON_VERSION//./} -s py${TRAVIS_PYTHON_VERSION//./}-extra -d /tmp/opt/openquake
+    - bash helpers/whlsetup.sh -${TRAVIS_PYTHON_VERSION:0:1} -c -s py -s py${TRAVIS_PYTHON_VERSION//./} -s py${TRAVIS_PYTHON_VERSION//./}-extra -d /tmp/opt/openquake
     - python${TRAVIS_PYTHON_VERSION} -c 'from openquake.libs import __version__; print(__version__)'

--- a/helpers/whlsetup.sh
+++ b/helpers/whlsetup.sh
@@ -142,7 +142,9 @@ if [ "$USE_PIP" == "true" ]; then
     find ${DEST} -name '*.pyc' -delete
 
     if [ ! -z $compile ]; then
-        /usr/bin/env $python -m compileall $DEST
+        # Python 2.7 is a bit fussy, compileall returns error even
+        # because of warnings we then force exit code 0 to make Travis happy
+        /usr/bin/env $python -m compileall $DEST || true
     fi
 else
     # FIXME: never happens

--- a/helpers/whlsetup.sh
+++ b/helpers/whlsetup.sh
@@ -138,8 +138,8 @@ if [ "$USE_PIP" == "true" ]; then
 
     # replace scripts hashbang with the python executable provided
     # by the system, instead of the one provided by virtualenv
-    find ${DEST}/bin -type f -print | xargs sed -i "s|${VENV}/bin/python.*|/usr/bin/env $python|g"
-    find ${DEST} -name '*.pyc' -delete
+    find ${DEST}/bin -type f -print0 | xargs -0 sed -i "s|${VENV}/bin/python.*|/usr/bin/env $python|g"
+    find ${DEST} -name '*.pyc' -o -name '__pycache__' -print0 | xargs -0 rm -Rf
 
     if [ ! -z $compile ]; then
         # Python 2.7 is a bit fussy, compileall returns error even

--- a/helpers/whlsetup.sh
+++ b/helpers/whlsetup.sh
@@ -142,7 +142,7 @@ if [ "$USE_PIP" == "true" ]; then
     find ${DEST} -name '*.pyc' -delete
 
     if [ ! -z $compile ]; then
-        /usr/bin/env $python -m compileall /opt/openquake
+        /usr/bin/env $python -m compileall $DEST
     fi
 else
     # FIXME: never happens


### PR DESCRIPTION
This PR add support for Python 3.5 in helpers script. An option to pre-compile cache (usually done by the packager) is also done. This makes the project able to bootstrap a local installation of the engine without using the packages, where needed (i.e. our cluster).

This is the first step towards having binary deb (or rpm, with RHEL 8) running on Python 3.