### PR TITLE
Add missing obsoletes in rpm

### DIFF
--- a/rpm/python3-oq-libs.spec.inc
+++ b/rpm/python3-oq-libs.spec.inc
@@ -56,6 +56,7 @@ Requires: oq-python35
 BuildRequires: oq-python35 sed
 
 Provides: python-oq-libs
+Obsoletes: python-oq-libs python2-oq-libs
 
 AutoReqProv: no
 AutoReq: no


### PR DESCRIPTION
After discussing about the upgrade path with @nastasi-oq I realized that I forgot to obsolete old python2 packages

```
Dependencies Resolved

===================================================================================================================================================================================================================
 Package                                  Arch                            Version                                               Repository                                                                    Size
===================================================================================================================================================================================================================
Installing:
 python3-oq-libs                          x86_64                          1.5.0-1518444855_gitec3efa3                           /python3-oq-libs-1.5.0-1518444855_gitec3efa3.x86_64                          342 M
     replacing  python-oq-libs.x86_64 1.5.0-1506446482_gite47998d
Installing for dependencies:
 oq-python35                              x86_64                          3.5.4-4.el7.centos                                    gem-openquake                                                                 22 M

Transaction Summary
===================================================================================================================================================================================================================
Install  1 Package (+1 Dependent package)
```

https://ci.openquake.org/job/builders/job/rpm-builder/113