### PR TITLE
Add packager

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Matteo Nastasi]
+  * Update packaging system to support python3.5 building on CI
+
 python3-oq-libs (2.0.0) stable; urgency=low
 
   [Daniele Viganò]

--- a/packager.sh
+++ b/packager.sh
@@ -102,6 +102,14 @@ sig_hand () {
 }
 
 #
+#  dep2var <dep> - converts in a proper way the name of a dependency to a variable name
+#      <dep>    the name of the dependency
+#
+dep2var () {
+    echo "$1" | sed 's/[-.]/_/g;s/\(.*\)/\U\1/g'
+}
+
+#
 #  repo_id_get - retry git repo from local git remote command
 repo_id_get () {
     local repo_name repo_line

--- a/packager.sh
+++ b/packager.sh
@@ -581,28 +581,28 @@ pkgtest_run () {
             deps_check_or_clone "$dep" "$repo/${dep}.git" "$branch_cur"
         fi
         pushd "_jenkins_deps/$dep"
-        commit="$(git log -1 | grep '^commit' | sed 's/^commit //g')"
+        dep_commit="$(git log -1 | grep '^commit' | sed 's/^commit //g')"
         popd
         echo "dependency: $dep"
         echo "repo:       $repo"
         echo "branch:     $branch_cur"
-        echo "commit:     $commit"
+        echo "commit:     $dep_commit"
         echo
         var_pfx="$(dep2var "$dep")"
         if [ ! -f _jenkins_deps_info ]; then
             touch _jenkins_deps_info
         fi
         if grep -q "^${var_pfx}_COMMIT=" _jenkins_deps_info; then
-            if ! grep -q "^${var_pfx}_COMMIT=$commit" _jenkins_deps_info; then
+            if ! grep -q "^${var_pfx}_COMMIT=$dep_commit" _jenkins_deps_info; then
                 echo "ERROR: $repo -> $branch_cur changed during test:"
                 echo "before:"
                 grep "^${var_pfx}_COMMIT=" _jenkins_deps_info
                 echo "after:"
-                echo "${var_pfx}_COMMIT=$commit"
+                echo "${var_pfx}_COMMIT=$dep_commit"
                 exit 1
             fi
         else
-            ( echo "${var_pfx}_COMMIT=$commit"
+            ( echo "${var_pfx}_COMMIT=$dep_commit"
               echo "${var_pfx}_REPO=$repo"
               echo "${var_pfx}_BRANCH=$branch_cur"
               echo "${var_pfx}_TYPE=$dep_type" ) >> _jenkins_deps_info

--- a/packager.sh
+++ b/packager.sh
@@ -705,7 +705,7 @@ while [ $# -gt 0 ]; do
                 echo
                 exit 1
             fi
-            BUILD_FLAGS="$BUILD_FLAGS $1 $2"
+            BUILD_FLAGS="$BUILD_FLAGS $1"
             shift
             ;;
         -S|--sources_copy)


### PR DESCRIPTION
With this PR we start to use local builds of oq-python3.5 instead of manually packaged and placed in `custom_pkgs` repository.
Now also oq-python3.5 package can be branched accordingly with the other packages to add new features and run tests consistently.
Tests are green here: https://ci.openquake.org/job/zdevel_oq-libs/58/