### PR TITLE
Fix a compatibility issue with new matplotlib in RPM

### DIFF
--- a/rpm/python3-oq-libs.spec.inc
+++ b/rpm/python3-oq-libs.spec.inc
@@ -124,11 +124,11 @@ end
 %defattr(-,root,root)
 %{_prefix}
 %exclude %{_libdir}/python3.5/site-packages/basemap*
-%exclude %{_libdir}/python3.5/site-packages/mpl_toolkits*
+%exclude %{_libdir}/python3.5/site-packages/mpl_toolkits/basemap
 
 %files extra
 %{_libdir}/python3.5/site-packages/basemap*
-%{_libdir}/python3.5/site-packages/mpl_toolkits*
+%{_libdir}/python3.5/site-packages/mpl_toolkits/basemap
 
 
 %changelog


### PR DESCRIPTION
Fixes #35 

This change was required by the way how `matplotlib` is packaged (we moved from 1.5 to 2.1 recently).

Ubuntu should not be affected by this bug because the way it packages sub-packages.