### PR TITLE
Jjrunner

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,9 @@
+python3-oq-libs (2.0.0-1) xenial; urgency=low
+
   [Matteo Nastasi]
   * Update packaging system to support python3.5 building on CI
+
+ -- Matteo Nastasi (GEM Foundation) <nastasi@openquake.org>  Wed, 09 May 2018 08:53:17 +0200
 
 python3-oq-libs (2.0.0) stable; urgency=low
 

--- a/packager.sh
+++ b/packager.sh
@@ -639,7 +639,7 @@ pkgtest_run () {
 Origin: openquake-${BUILD_UBUVER}
 Label: OpenQuake Local Ubuntu Repository
 Codename: $BUILD_UBUVER
-Date: $(date -R)
+Date: $(date -R -u)
 Architectures: amd64
 Components: main
 Description: OpenQuake Local Ubuntu Repository

--- a/packager.sh
+++ b/packager.sh
@@ -190,10 +190,10 @@ _wait_ssh () {
 add_custom_pkg_repo () {
     # install package to manage repository properly
     ssh $lxc_ip "sudo apt-get install -y python-software-properties software-properties-common"
-    return
+
     # add custom packages
     if ! ssh $lxc_ip ls repo/custom_pkgs >/dev/null ; then
-        ssh $lxc_ip mkdir "repo"
+        ssh $lxc_ip mkdir -p "repo"
         scp -r ${GEM_DEB_REPO}/custom_pkgs $lxc_ip:repo/custom_pkgs
     fi
     ssh $lxc_ip "sudo apt-add-repository \"deb file:/home/ubuntu/repo/custom_pkgs ${BUILD_UBUVER} main\""
@@ -226,6 +226,7 @@ add_local_pkg_repo () {
     from_dir="${GEM_DEB_REPO}/${BUILD_UBUVER}/${GEM_DEB_SERIE}/${dep_pkg}.${!var_commit:0:7}"
     time_start="$(date +%s)"
     while true; do
+        ssh "$lxc_ip" mkdir -p "repo"
         if scp -r "$from_dir" "$lxc_ip:repo/${dep_pkg}"; then
             break
         fi
@@ -242,7 +243,7 @@ add_local_pkg_repo () {
             #       so we try to get the correct commit package and if it isn't yet built
             #       it fallback to the latest builded
             from_dir="$(ls -drt "${GEM_DEB_REPO}/${BUILD_UBUVER}/${GEM_DEB_SERIE}/${dep_pkg}"* | tail -n 1)"
-            ssh $lxc_ip "mkdir -p repo"
+            ssh $lxc_ip mkdir -p "repo"
             scp -r "$from_dir" "$lxc_ip:repo/${dep_pkg}"
             break
         fi
@@ -335,7 +336,7 @@ _pkgtest_innervm_run () {
     ssh $lxc_ip "sudo apt-get install -y python-software-properties"
 
     # create a remote "local repo" where place $GEM_DEB_PACKAGE package
-    ssh $lxc_ip mkdir -p repo/${GEM_DEB_PACKAGE}
+    ssh $lxc_ip mkdir -p "repo/${GEM_DEB_PACKAGE}"
     scp build-deb/${GEM_DEB_PACKAGE}*.deb build-deb/${GEM_DEB_PACKAGE}*.changes \
         build-deb/${GEM_DEB_PACKAGE}*.dsc build-deb/${GEM_DEB_PACKAGE}*.tar.*z \
         build-deb/Packages* build-deb/Sources*  build-deb/Release* $lxc_ip:repo/${GEM_DEB_PACKAGE}

--- a/packager.sh
+++ b/packager.sh
@@ -657,7 +657,7 @@ EOF
         $(wc --bytes Sources | cut --delimiter=' ' --fields=1) >> Release
     printf ' '$(sha256sum Sources.gz | cut --delimiter=' ' --fields=1)' %16d Sources.gz\n' \
         $(wc --bytes Sources.gz | cut --delimiter=' ' --fields=1) >> Release
-    gpg --armor --detach-sign --output Release.gpg Release
+    gpg --armor --detach-sign --output Release.gpg --local-user "$DEBFULLNAME" Release
     cd -
 
     sudo echo

--- a/packager.sh
+++ b/packager.sh
@@ -48,6 +48,10 @@ fi
 if [ -z "$GEM_DEB_MONOTONE" ]; then
     GEM_DEB_MONOTONE="$HOME/monotone"
 fi
+if [ -z "$GEM_MASTER_BRANCH" ]; then
+    export GEM_MASTER_BRANCH="master"
+fi
+
 # FIXME this is currently unused, but left as reference
 if [ "$GEM_EPHEM_USER" = "" ]; then
     GEM_EPHEM_USER="ubuntu"
@@ -218,7 +222,7 @@ add_local_pkg_repo () {
         dep_branch="master"
     fi
 
-    if [ "$dep_repo" = "$GEM_GIT_REPO" -a "$dep_branch" = "master" ]; then
+    if [ "$dep_repo" = "$GEM_GIT_REPO" -a "$dep_branch" = "$GEM_MASTER_BRANCH" ]; then
         GEM_DEB_SERIE="master"
     else
         GEM_DEB_SERIE="devel/$(echo "$dep_repo" | sed 's@^.*://@@g;s@/@__@g;s/\./-/g')__${dep_branch}"
@@ -683,7 +687,7 @@ EOF
             fi
             if [ "$branch_id" != "" ]; then
                 repo_id="$(repo_id_get)"
-                if [ "git://$repo_id" != "$GEM_GIT_REPO" -o "$branch_id" != "master" ]; then
+                if [ "git://$repo_id" != "$GEM_GIT_REPO" -o "$branch_id" != "$GEM_MASTER_BRANCH" ]; then
                     CUSTOM_SERIE="devel/$(echo "$repo_id" | sed "s@/@__@g;s/\./-/g")__${branch_id}"
                     if [ "$CUSTOM_SERIE" != "" ]; then
                         GEM_DEB_SERIE="$CUSTOM_SERIE"
@@ -695,7 +699,7 @@ EOF
 
             # if the monotone directory exists and is the "gem" repo and is the "master" branch then ...
             if [ -d "${GEM_DEB_MONOTONE}/${ubu_serie}/binary" ]; then
-                if [ "git://$repo_id" == "$GEM_GIT_REPO" -a "$branch_id" == "master" ]; then
+                if [ "git://$repo_id" == "$GEM_GIT_REPO" -a "$branch_id" == "$GEM_MASTER_BRANCH" ]; then
                     cp build-deb/${GEM_DEB_PACKAGE}*.deb build-deb/${GEM_DEB_PACKAGE}*.changes \
                        build-deb/${GEM_DEB_PACKAGE}*.dsc build-deb/${GEM_DEB_PACKAGE}*.tar.*z \
                        "${GEM_DEB_MONOTONE}/${ubu_serie}/binary"

--- a/packager.sh
+++ b/packager.sh
@@ -344,7 +344,6 @@ _pkgtest_innervm_run () {
     scp build-deb/${GEM_DEB_PACKAGE}*.deb build-deb/${GEM_DEB_PACKAGE}*.changes \
         build-deb/${GEM_DEB_PACKAGE}*.dsc build-deb/${GEM_DEB_PACKAGE}*.tar.*z \
         build-deb/Packages* build-deb/Sources*  build-deb/Release* $lxc_ip:repo/${GEM_DEB_PACKAGE}
-    ssh $lxc_ip "sudo apt-get install -y python-software-properties software-properties-common"
     ssh $lxc_ip "sudo apt-add-repository \"deb file:/home/ubuntu/repo/${GEM_DEB_PACKAGE} ./\""
 
     if [ -f _jenkins_deps_info ]; then
@@ -421,7 +420,7 @@ _builddoc_innervm_run () {
 
     gpg -a --export | ssh $lxc_ip "sudo apt-key add -"
     # install package to manage repository properly
-    # ssh $lxc_ip "sudo apt-get install -y python-software-properties"
+    ssh $lxc_ip "sudo apt-get install -y software-properties-common"
 
     pkgs_list="$(deps_list all debian)"
     ssh $lxc_ip "sudo apt-get install -y ${pkgs_list}"


### PR DESCRIPTION
  - use value of GEM_MASTER_BRANCH var instead of "``master``" as identifier of main branch.
  - use ``--local-user`` argument to sign ``Release`` file with proper key
  - use date in UTC format as date of ``Release`` file
  - reintroduced ~\<serie\> in the version naming
Tests are green here: https://ci.openquake.org/job/zdevel_oq-libs/64/