### PR TITLE
Update requests requirements because of CVE-2018-18074

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Daniele Viganò]
+  * Update 'requests' wheel from 2.18.4 to 2.20.0
+    because of CVE-2018-18074
+
 python3-oq-libs (2.2.0-1~xenial01) xenial; urgency=low
 
   [Daniele Viganò]

--- a/doc/wheels.md
+++ b/doc/wheels.md
@@ -18,7 +18,7 @@
 - pytz==2018.3
 - PyYAML==3.12
 - pyzmq==16.0.4
-- requests==2.18.4
+- requests==2.20.0
 - Rtree==0.8.2
 - scipy==1.0.1
 - setproctitle==1.1.10

--- a/openquake/libs/__init__.py
+++ b/openquake/libs/__init__.py
@@ -16,4 +16,4 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = '2.2.0'
+__version__ = '2.2.1'

--- a/py/requirements-bin.txt
+++ b/py/requirements-bin.txt
@@ -19,7 +19,7 @@ pyshp-1.2.3-py3-none-any.whl
 python_dateutil-2.7.2-py2.py3-none-any.whl
 python_pam-1.8.3-py2.py3-none-any.whl
 pytz-2018.3-py2.py3-none-any.whl
-requests-2.18.4-py2.py3-none-any.whl
+requests-2.20.0-py2.py3-none-any.whl
 six-1.11.0-py2.py3-none-any.whl
 urllib3-1.22-py2.py3-none-any.whl
 vine-1.1.4-py2.py3-none-any.whl


### PR DESCRIPTION
Upstream: https://github.com/gem/oq-engine/pull/4133

https://ci.openquake.org/job/zdevel_oq-libs/68/
https://ci.openquake.org/job/zdevel_oq-engine/2816/