### PR TITLE
 Purge wheels by default, add a -k to keep cache

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -3,11 +3,11 @@ Upstream-Name: python-oq-engine
 Source: http://github.com/gem/oq-engine
 
 Files: *
-Copyright: 2012-2018 GEM Foundation
+Copyright: 2012-2019 GEM Foundation
 License: AGPL3
 
 Files: debian/*
-Copyright: 2012-2018, Matteo Nastasi (GEM Foundation) <nastasi@openquake.org>
+Copyright: 2012-2019, Matteo Nastasi (GEM Foundation) <nastasi@openquake.org>
 License: AGPL3
 
 License: AGPL3

--- a/helpers/makedeb.sh
+++ b/helpers/makedeb.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
+#
+# makedeb.sh  Copyright (C) 2016-2019 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>
+
+if [ $GEM_SET_DEBUG ]; then
+    set -x
+fi
 set -e
+
 export PATH="/opt/openquake/bin:$PATH"
 GEM_GIT_PACKAGE="oq-libs"
 GEM_DEB_PACKAGE="python3-${GEM_GIT_PACKAGE}"

--- a/helpers/makerpm.sh
+++ b/helpers/makerpm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# makerpm.sh  Copyright (C) 2015-2018 GEM Foundation
+# makerpm.sh  Copyright (C) 2015-2019 GEM Foundation
 #
 # OpenQuake is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published
@@ -15,8 +15,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>
 
-# Work in progress
-
+if [ $GEM_SET_DEBUG ]; then
+    set -x
+fi
 set -e
 
 CUR=$(pwd)

--- a/helpers/whldownload.sh
+++ b/helpers/whldownload.sh
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #
-# Copyright (C) 2016-2018 GEM Foundation
+# Copyright (C) 2016-2019 GEM Foundation
 #
 # OpenQuake is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published

--- a/helpers/whldownload.sh
+++ b/helpers/whldownload.sh
@@ -26,12 +26,13 @@ help() {
     cat <<HSD
 USAGE:
 
-$0 [-m <mirror-url>] -w <dir1> [-w <dir2> []]
+$0 [-m <mirror-url>] -w <dir1> [-w <dir2> []] -k
 $0 -h
 
 The command line arguments are as follows:
     -w, --wheelhouse     Destination target where Python code wil be installed
     -m, --mirror         Mirror to use
+    -k, --keep           Keep existing wheels
     -h, --help           This help
 HSD
 }
@@ -73,6 +74,10 @@ while [ $# -gt 0 ]; do
             MIRROR="$2"
             shift 2
             ;;
+        -k|--keep)
+            KEEP=1
+            shift
+            ;;
         *)
             help
             exit 1
@@ -84,6 +89,9 @@ checkcmd curl
 
 for d in "${WH[@]}"; do
     cd $d
+    if [ -z $KEEP ]; then
+        rm -f *.whl
+    fi
     cat requirements-bin.txt | while read l; do
         if [ ${l:0:1} == "#" ]; then
             continue

--- a/helpers/whlsetup.sh
+++ b/helpers/whlsetup.sh
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #
-# Copyright (C) 2016-2018 GEM Foundation
+# Copyright (C) 2016-2019 GEM Foundation
 #
 # OpenQuake is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published

--- a/openquake/__init__.py
+++ b/openquake/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #
-# Copyright (C) 2010-2018 GEM Foundation
+# Copyright (C) 2010-2019 GEM Foundation
 #
 # OpenQuake is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published

--- a/openquake/libs/__init__.py
+++ b/openquake/libs/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 #
-# Copyright (C) 2010-2018 GEM Foundation
+# Copyright (C) 2010-2019 GEM Foundation
 #
 # OpenQuake is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published

--- a/packager.sh
+++ b/packager.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# packager.sh  Copyright (C) 2014-2018 GEM Foundation
+# packager.sh  Copyright (C) 2014-2019 GEM Foundation
 #
 # OpenQuake is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published

--- a/rpm/python3-oq-libs.spec.inc
+++ b/rpm/python3-oq-libs.spec.inc
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: syntax=spec
 #
-# Copyright (C) 2015-2018 GEM Foundation
+# Copyright (C) 2015-2019 GEM Foundation
 #
 # OpenQuake is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published
@@ -80,7 +80,7 @@ Libraries for OpenQuake
 OpenQuake is an open source application that allows users to
 compute seismic hazard and seismic risk of earthquakes on a global scale.
 
-Copyright (C) 2010-2018 GEM Foundation
+Copyright (C) 2010-2019 GEM Foundation
 
 
 %package extra
@@ -95,7 +95,7 @@ Extra libraries for OpenQuake
 OpenQuake is an open source application that allows users to
 compute seismic hazard and seismic risk of earthquakes on a global scale.
 
-Copyright (C) 2010-2018 GEM Foundation
+Copyright (C) 2010-2019 GEM Foundation
 
 %prep
 %setup -n %{oqformat}


### PR DESCRIPTION
Purge the wheelhouses unless `-k` is passed. In local installation (i.e. not on CI) it's dangerous to keep the old downloaded wheels, especially when versions of libraries are changed. Multiple versions of the same libs can be otherwise collected by the packager(which is bad).

Also align scrips and add/update &copy;